### PR TITLE
Require annotate plugin for tooltips

### DIFF
--- a/plugins/focus/index.js
+++ b/plugins/focus/index.js
@@ -8,9 +8,7 @@
 
 let $ = require('jquery')
 let Plugin = require('../base')
-
-let outlineItemTemplate = require('./index.js')
-require('./index.js')
+let annotate = require("../shared/annotate")("focus");
 
 class FocusPlugin extends Plugin {
   getTitle () {
@@ -24,9 +22,11 @@ class FocusPlugin extends Plugin {
   }
   run () {
     var results = getTabbablesInOrder(document.querySelector('body'))
+    let tota11y_dashboard = document.getElementById("tota11y-toolbar");
     results.forEach(function (element, index) {
-      $(this).addClass('tota11y-focus') // so we can find them again
-      annotate.errorLabel($(this), 'Empty!', $(this).prop('tagName'))
+      if (tota11y_dashboard.contains(element)) return; // exclude the tota11y dashboard itself!
+      $(element).addClass('tota11y-focus') // so we can find them again
+      annotate.errorLabel($(element), 'Tab index ' + index, $(element).prop('tagName'))
     })
 
     function getTabbablesInOrder (within) {


### PR DESCRIPTION
Array.forEach is a vanilla JS way of iterating arrays, so you can't use jQuery's $(this) inside it to mean "the element for this loop".
Instead, use element, our callback's variable, and jQueryify it as $(element) so we can use addClass on it and hand it to annotate.